### PR TITLE
Add InOrder documentation and made InOrder greedy

### DIFF
--- a/Sources/SwiftMock/ArgumentMatcher/ArgumentMatcherAnd.swift
+++ b/Sources/SwiftMock/ArgumentMatcher/ArgumentMatcherAnd.swift
@@ -1,8 +1,6 @@
 /// Creates an argument matcher that tests an argument with two provided ``ArgumentMatcher``.
 /// Created ``ArgumentMatcher`` tests that argument satisfies both provided matchers.
 ///
-/// - Parameters:
-///
 ///	- Parameters:
 ///		- mather0: First argument mather. If this argumen matcher unsuccessfully tests an argument,
 ///			the second one won't be called.

--- a/Sources/SwiftMock/Documentation.docc/Documentation.md
+++ b/Sources/SwiftMock/Documentation.docc/Documentation.md
@@ -25,6 +25,10 @@ The ``verify(_:times:)`` function is used to verify the call of your mocks. This
 - <doc:Argument-Matchers>
 - <doc:Verifying>
 
+### Engine
+
+- <doc:Greedy-Algorithm>
+
 ### Basic
 
 - ``when(_:)-2f4dp``
@@ -32,6 +36,11 @@ The ``verify(_:times:)`` function is used to verify the call of your mocks. This
 - ``when(_:)-1l8q0``
 - ``when(_:)-35bf6``
 - ``verify(_:times:)``
+- ``inOrder(_:)``
+
+### Verifying
+
+- ``InOrder``
 
 ### Argument Mathers
 
@@ -84,3 +93,9 @@ The ``verify(_:times:)`` function is used to verify the call of your mocks. This
 
 - ``MethodCall``
 - ``Verifiable``
+
+### Internal Containers
+
+- ``CallContainer``
+- ``VerifyContainer``
+

--- a/Sources/SwiftMock/Documentation.docc/Engine/Greedy Algorithm.md
+++ b/Sources/SwiftMock/Documentation.docc/Engine/Greedy Algorithm.md
@@ -1,0 +1,86 @@
+# Greedy Algorithm
+
+Greedy algorithm of verification ``InOrder``.
+
+### Understanding 'greedy' algorithm
+
+In ``SwiftMock`` verification ``inOrder(_:)`` mode is greedy. Example:
+
+```swift
+mock.foo()
+mock.foo()
+mock.bar()
+```
+
+```swift
+// greedy algorithm (``SwiftMock`` way):
+inOrder.verify(mock, times: times(2)).foo() // pass - I'm greedy - called 2 times, must be times(2)
+inOrder.verify(mock, times: times(1)).bar() // pass
+
+// non-greedy algorithm allows this:
+inOrder.verify(mock, times: times(1)).foo(; // pass - I'm not greedy, one instance is enough
+inOrder.verify(mock, times: times(1)).bar() // pass
+```
+Non-greedy algorithm seems more intuitive: when you read the verification if feels right: one instance of `foo()` was called before one instance `bar()`. However non-greedy algorithm is not consistent with standard verification in ``SwiftMock`` where `times(x)` is rigid. Also non-greedy may lead to:
+* may lead contradicting assertion statements that pass (e.g. same verifications but with different `times(x)` pass)
+* may lead inability to verify the exact number of invocations occasionally
+* may lead to bugs
+
+Hence our design choice was to go for 'greedy' algorithm when verifying in order.
+
+### Theoretical example where non-greedy algorithm leads to bugs
+
+```swift
+// production code:
+service.saveEntity()
+service.commit()
+
+// test:        
+inOrder.verify(service, times: times(1)).saveEntity() // this has to happen *once*
+inOrder.verify(service, times: times(1)).commit()
+```
+
+Later on the bug is introduced:
+
+```swift
+// production code:
+service.saveEntity()
+service.saveEntity() // <<-- dev introduces bug: saving the entity twice leads to memory corruption
+service.commit()
+
+// non-greedy algorithm does not detect the bug and the *test passes*
+inOrder.verify(service, times: times(1)).saveEntity() // <<-- passes in non-greedy mode
+inOrder.verify(service).commit()
+
+// greedy algorithm *detects the bug*
+inOrder.verify(service, times: times(1)).saveEntity() // <<-- fails in greedy mode
+inOrder.verify(service).commit()
+```
+
+> Note: This example is theoretical. We didn't find a real use case in production code that would asses what is better: greedy or non-greedy algorithm. This seems to be a truly edge case. Decent, KISSy, refactored code should be easy to test without acrobatics.
+
+### More complex examples
+
+Using ``atLeast(_:)`` mode in order.
+
+```swift
+mock.add("A")
+mock.add("A")
+mock.add("B")
+mock.add("A")
+```
+
+Explanation of *greedy* algorithm:
+
+```swift
+// fails:
+inOrder.verify(mock, times: atLeast(2)).add(eq("A"))
+inOrder.verify(mock, times: atLeast(1)).add(eq("B"))
+
+// passes:
+inOrder.verify(mock, times: times(2)).add(eq("A"))
+inOrder.verify(mock, times: atLeast(1)).add(rq("B"))
+
+// atLeast(x) may not fit the greedy paradigm but again...
+// the API should be consistent
+```

--- a/Sources/SwiftMock/Documentation.docc/Usage/Verifying.md
+++ b/Sources/SwiftMock/Documentation.docc/Usage/Verifying.md
@@ -112,7 +112,7 @@ func test() {
 
 ### Checking that method was called specific times
 
-The ``verify(_:times:)`` method can check not only that the method was called once, but also a specific number of times. The `times` parameter of the ``verify(_:times:)`` method is used for this. This parameter type is ``TimesMatcher`` and you can use ``times(_:)``, ``never()``, ``atLeast(_:)``, ``atMost(_:)`` as examples, or create your own.
+The ``verify(_:times:)`` function can check not only that the method was called once, but also a specific number of times. The `times` parameter of the ``verify(_:times:)`` method is used for this. This parameter type is ``TimesMatcher`` and you can use ``times(_:)``, ``never()``, ``atLeast(_:)``, ``atMost(_:)`` as examples, or create your own.
 
 The following example checks that the method has been called at least twice.
 
@@ -138,3 +138,38 @@ func test() {
 ```
 
 > Important: Using ``atLeast(_:)`` and ``atMost(_:)`` will mark all calls that match the passed ``ArgumentMatcher``s as verified.
+
+### Verification in order
+
+The ``inOrder(_:)`` function allows you to check that mock methods were called in a certain order. To do this, you need to call the ``inOrder(_:)`` function and pass there the mocks for interaction with which you want to check. The function returns the ``InOrder`` class which has a ``InOrder/verify(_:times:)`` method that works similar to the function of the same name.
+
+```swift 
+@Mock
+public protocol AlbumService {
+	func getAlbumName(id: String) async throws -> String
+}
+
+
+func test() {
+	let mock = AlbumServiceMock()
+
+	when(mock.$getAlbumName())
+		.thenReturn("#4")
+		.thenReturn("Inspiration Is Dead")
+
+	let inOrder = inOrder(mock)
+
+	_ = mock.getAlbumName(id: "id1")
+	_ = mock.getAlbumName(id: "id2")
+	
+	// Check that method was called with id: "id1"
+	inOrder.verify(mock).getAlbumName(id: eq("id1")) 
+	// Check that method was called with id: "id2"
+	// after than with id: "id1"
+	inOrder.verify(mock).getAlbumName(id: eq("id2"))
+}
+```
+
+> Tips: Verification in order is flexible - you don't have to verify all interactions one-by-one but only those that you are interested in testing in order.
+
+> Important: ``InOrder`` verification is 'greedy', but you will hardly ever notice it. If you want to find out more, read: <doc:Greedy-Algorithm>.

--- a/Sources/SwiftMock/Functions.swift
+++ b/Sources/SwiftMock/Functions.swift
@@ -6,27 +6,27 @@ import Foundation
 ///
 /// Examples:
 ///
-/// ~~~
+/// ```swift
 /// when(mock.$someMethod()).thenReturn(10)
-/// ~~~
+/// ```
 ///
 /// You can use flexible argument matchers, e.g:
-/// ~~~
+/// ```swift
 /// when(mock.$someMethod(argument: any())).thenReturn(10)
-///	~~~
+///	```
 ///
 /// Setting exception to be thrown:
-/// ~~~
+/// ```swift
 /// when(mock.$someMethod(argument: eq("some arg"))).thenThrow(SomeError.error)
-/// ~~~
+/// ```
 ///
 /// You can set different behavior for consecutive method calls.
 /// Last stubbing (e.g: thenReturn("foo")) determines the behavior of further consecutive calls.
-/// ~~~
+/// ```swift
 /// when(mock.$someMethod(argument: eq("some arg")))
 /// 	.thenThrow(SomeError.error)
 /// 	.thenReturn("foo")
-/// ~~~
+/// ```
 ///
 /// - Note: Stubbing can be overridden: for example common stubbing can go to fixture
 /// 	setup but the test methods can override it.
@@ -50,27 +50,27 @@ public func when<Arguments, Result>(
 ///
 /// Examples:
 ///
-/// ~~~
+/// ```swift
 /// when(mock.$someMethod()).thenReturn(10)
-/// ~~~
+/// ```
 ///
 /// You can use flexible argument matchers, e.g:
-/// ~~~
+/// ```swift
 /// when(mock.$someMethod(argument: any())).thenReturn(10)
-///	~~~
+///	```
 ///
 /// Setting exception to be thrown:
-/// ~~~
+/// ```swift
 /// when(mock.$someMethod(argument: eq("some arg"))).thenThrow(SomeError.error)
-/// ~~~
+/// ```
 ///
 /// You can set different behavior for consecutive method calls.
 /// Last stubbing (e.g: thenReturn("foo")) determines the behavior of further consecutive calls.
-/// ~~~
+/// ```swift
 /// when(mock.$someMethod(argument: eq("some arg")))
 /// 	.thenThrow(SomeError.error)
 /// 	.thenReturn("foo")
-/// ~~~
+/// ```
 ///
 /// - Note: Stubbing can be overridden: for example common stubbing can go to fixture
 /// 	setup but the test methods can override it.
@@ -94,27 +94,27 @@ public func when<Arguments, Result>(
 ///
 /// Examples:
 ///
-/// ~~~
+/// ```swift
 /// when(mock.$someMethod()).thenReturn(10)
-/// ~~~
+/// ```
 ///
 /// You can use flexible argument matchers, e.g:
-/// ~~~
+/// ```swift
 /// when(mock.$someMethod(argument: any())).thenReturn(10)
-///	~~~
+///	```
 ///
 /// Setting exception to be thrown:
-/// ~~~
+/// ```swift
 /// when(mock.$someMethod(argument: eq("some arg"))).thenThrow(SomeError.error)
-/// ~~~
+/// ```
 ///
 /// You can set different behavior for consecutive method calls.
 /// Last stubbing (e.g: thenReturn("foo")) determines the behavior of further consecutive calls.
-/// ~~~
+/// ```swift
 /// when(mock.$someMethod(argument: eq("some arg")))
 /// 	.thenThrow(SomeError.error)
 /// 	.thenReturn("foo")
-/// ~~~
+/// ```
 ///
 /// - Note: Stubbing can be overridden: for example common stubbing can go to fixture
 /// 	setup but the test methods can override it.
@@ -138,27 +138,27 @@ public func when<Arguments, Result>(
 ///
 /// Examples:
 ///
-/// ~~~
+/// ```swift
 /// when(mock.$someMethod()).thenReturn(10)
-/// ~~~
+/// ```
 ///
 /// You can use flexible argument matchers, e.g:
-/// ~~~
+/// ```swift
 /// when(mock.$someMethod(argument: any())).thenReturn(10)
-///	~~~
+///	```
 ///
 /// Setting exception to be thrown:
-/// ~~~
+/// ```swift
 /// when(mock.$someMethod(argument: eq("some arg"))).thenThrow(SomeError.error)
-/// ~~~
+/// ```
 ///
 /// You can set different behavior for consecutive method calls.
 /// Last stubbing (e.g: thenReturn("foo")) determines the behavior of further consecutive calls.
-/// ~~~
+/// ```swift
 /// when(mock.$someMethod(argument: eq("some arg")))
 /// 	.thenThrow(SomeError.error)
 /// 	.thenReturn("foo")
-/// ~~~
+/// ```
 ///
 /// - Note: Stubbing can be overridden: for example common stubbing can go to fixture
 /// 	setup but the test methods can override it.
@@ -176,10 +176,48 @@ public func when<Arguments, Result>(
 	)
 }
 
+/// Creates a `Verify` structure specific to a mock object whose method calls need to be verified.
+///
+/// - Parameters:
+/// 	- mock: Mock object  whose method calls need to be verified.
+/// 	- times: How many calls do we want to check.
+/// - Returns: New `Verify` structure specific to a mock object.
+///
+/// Verifies certain behavior happened at least once/exact number of times/never. E.g:
+/// ```swift
+///	verify(mock, times: times(5)).someMethod(argument: eq("was called five times"))
+///
+///	verify(mock, times: atLeast(2)).someMethod(argument: eq("was called at least two times"))
+///
+///	verify(mock, times: atLeastOnce()).someMethod()
+/// ```
+///
+/// **`times(1)` is the default** and can be omitted.
+///
+/// Arguments passed are compared using ``ArgumentMatcher``.
+/// Read about ``ArgumentMatcher`` to find out other ways of matching / asserting arguments passed.
+/// <p>
 public func verify<Mock: Verifiable>(_ mock: Mock, times: @escaping TimesMatcher = times(1)) -> Mock.Verify {
 	Mock.Verify(mock: mock, container: mock.container, times: times)
 }
 
-public func inOrder(_ mock: AnyObject...) -> InOrder {
-	InOrder(mock)
+/// Creates new ``InOrder`` struct with 0 (zero) offset of call stack.
+///
+/// - Parameters:
+/// 	- mocks: Mock objects whose method calling order needs to be verified.
+///
+/// - Returns: New ``InOrder`` struct.
+///
+/// ```swift
+/// let inOrder = inOrder(firstMock, secondMock)
+///
+/// inOrder.verify(firstMock).add(eq("was called first"))
+/// inOrder.verify(secondMock).add(eq("was called second"))
+/// ```
+/// Verification in order is flexible - **you don't have to verify all interactions** one-by-one
+/// but only those that you are interested in testing in order.
+///
+/// Also, you can create InOrder object passing only mocks that are relevant for in-order verification.
+public func inOrder(_ mocks: AnyObject...) -> InOrder {
+	InOrder(mocks)
 }

--- a/Sources/SwiftMock/InOrder/InOrder.swift
+++ b/Sources/SwiftMock/InOrder/InOrder.swift
@@ -5,6 +5,7 @@
 //  Created by Alexandr Zalutskiy on 12/10/2023.
 //
 
+/// Struct that allows you to check that mock methods were called in a certain order.
 public struct InOrder {
 	private let mocks: [AnyObject]
 	
@@ -15,6 +16,15 @@ public struct InOrder {
 		self.container = InOrderContainer()
 	}
 	
+	/// Create `Verify` struct that allows you to check next method on specific mock object.
+	///
+	/// - Parameters:
+	/// 	- mock: Mock the object whose method call we are checking.
+	///		- times: How many calls do we want to check.
+	///
+	///	- Returns: `Verify` structure specific to the passed mock object.
+	///
+	///	- Note: You don't have to verify all interactions one-by-one but only those that you are interested in testing in order.
 	public func verify<Mock: AnyObject & Verifiable>(_ mock: Mock, times: @escaping TimesMatcher = times(1)) -> Mock.Verify {
 		guard mocks.contains(where: { $0 === mock }) else {
 			testFailureReport("")

--- a/Sources/SwiftMock/InOrder/InOrderContainer.swift
+++ b/Sources/SwiftMock/InOrder/InOrderContainer.swift
@@ -49,6 +49,9 @@ class InOrderContainer: CallContainer {
 		var lastCheckedIndex = startIndex
 
 		for index in startIndex..<calls.endIndex {
+			guard mock === mocks[index] else {
+				continue
+			}
 			guard functions[index] == function else {
 				continue
 			}
@@ -60,10 +63,6 @@ class InOrderContainer: CallContainer {
 			}
 			
 			callCount += 1
-			
-			if times(callCount) {
-				break
-			}
 		}
 		guard times(callCount) else {
 			testFailureReport("\(type).\(function): incorrect calls count: \(callCount)")

--- a/Tests/SwiftMockTests/InOrderTests.swift
+++ b/Tests/SwiftMockTests/InOrderTests.swift
@@ -96,8 +96,7 @@ final class InOrderTests: XCTestCase {
 		
 		let inOrder = inOrder(mock0, mock1)
 		
-		inOrder.verify(mock0).call()
-		inOrder.verify(mock1).call()
+		inOrder.verify(mock0, times: times(2)).call()
 		inOrder.verify(mock0).call0()
 		
 	}


### PR DESCRIPTION
* Add documentation to InOrder verification.
* Change InOrder algorithm to 'greedy'. This makes API more consistent because general verify functional is 'greedy' too.