### PR TITLE
Remove extra space after protocol name

### DIFF
--- a/Sources/SwiftMockMacros/SwiftMockMacro.swift
+++ b/Sources/SwiftMockMacros/SwiftMockMacro.swift
@@ -31,7 +31,7 @@ public struct MockMacro: PeerMacro {
 						genericParameterClause: try AssociatedTypePrecessor.makeGenericParameterClause(associatedTypeDecls: associatedTypeDecls),
 						inheritanceClause: InheritanceClauseSyntax {
 							if declaration.attributes.contains(where: { $0.isObjc }) { InheritedTypeSyntax(type: TypeSyntax.nsObject) }
-							InheritedTypeSyntax(type: IdentifierTypeSyntax(name: declaration.name))
+							InheritedTypeSyntax(type: IdentifierTypeSyntax(name: declaration.name.trimmingCharacters(in: .whitespacesAndNewlines)))
 							InheritedTypeSyntax(type: IdentifierTypeSyntax(name: "Verifiable"))
 						}
 					) {

--- a/Tests/SwiftMockTests/Macro/MockMacroAssociatedTypesTests.swift
+++ b/Tests/SwiftMockTests/Macro/MockMacroAssociatedTypesTests.swift
@@ -33,7 +33,7 @@ final class MockMacroAssociatedTypesTests: XCTestCase {
 				associatedtype A
 			}
 			
-			final class TestMock<A>: Test , Verifiable {
+			final class TestMock<A>: Test, Verifiable {
 				struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -72,7 +72,7 @@ final class MockMacroAssociatedTypesTests: XCTestCase {
 				associatedtype B
 			}
 			
-			final class TestMock<A, B>: Test , Verifiable {
+			final class TestMock<A, B>: Test, Verifiable {
 				struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -109,7 +109,7 @@ final class MockMacroAssociatedTypesTests: XCTestCase {
 				associatedtype A: Encodable
 			}
 			
-			final class TestMock<A: Encodable>: Test , Verifiable {
+			final class TestMock<A: Encodable>: Test, Verifiable {
 				struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -146,7 +146,7 @@ final class MockMacroAssociatedTypesTests: XCTestCase {
 				associatedtype A: Decodable, Encodable
 			}
 			
-			final class TestMock<A: Decodable & Encodable>: Test , Verifiable {
+			final class TestMock<A: Decodable & Encodable>: Test, Verifiable {
 				struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer

--- a/Tests/SwiftMockTests/Macro/MockMacroGenericMethodTests.swift
+++ b/Tests/SwiftMockTests/Macro/MockMacroGenericMethodTests.swift
@@ -26,7 +26,7 @@ final class MockMacroGenericMethodTests: XCTestCase {
 				func call<T>(_ argument: T)
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -82,7 +82,7 @@ final class MockMacroGenericMethodTests: XCTestCase {
 				func call<T>(_ argument: T) -> T
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -138,7 +138,7 @@ final class MockMacroGenericMethodTests: XCTestCase {
 				func call<T: Equitable & Hashable>(_ argument: T) -> T
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -194,7 +194,7 @@ final class MockMacroGenericMethodTests: XCTestCase {
 				func call<T: Equitable & Hashable>(_ argument: T) async throws -> T
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer

--- a/Tests/SwiftMockTests/Macro/MockMacroMethodTests.swift
+++ b/Tests/SwiftMockTests/Macro/MockMacroMethodTests.swift
@@ -33,7 +33,7 @@ final class MockMacroMethodTests: XCTestCase {
 				func test(_ f: @escaping (Int) -> Void)
 			}
 			
-			final class TestMock: Test , Verifiable {
+			final class TestMock: Test, Verifiable {
 				struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -86,7 +86,7 @@ final class MockMacroMethodTests: XCTestCase {
 				func test(_ f: (Int) -> Void)
 			}
 			
-			final class TestMock: Test , Verifiable {
+			final class TestMock: Test, Verifiable {
 				struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer

--- a/Tests/SwiftMockTests/Macro/MockMacroSubscriptTests.swift
+++ b/Tests/SwiftMockTests/Macro/MockMacroSubscriptTests.swift
@@ -26,7 +26,7 @@ final class MockMacroSubscriptTests: XCTestCase {
 				subscript(_ value: Int) -> Int { get }
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -82,7 +82,7 @@ final class MockMacroSubscriptTests: XCTestCase {
 				subscript(_ value: Int) -> Int { get set }
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -156,7 +156,7 @@ final class MockMacroSubscriptTests: XCTestCase {
 				subscript<T: Equitable>(_ value: T) -> T { get set }
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -230,7 +230,7 @@ final class MockMacroSubscriptTests: XCTestCase {
 				subscript(_ value0: Int, _ value1: Int) -> Int { get }
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer

--- a/Tests/SwiftMockTests/Macro/MockMacroTests.swift
+++ b/Tests/SwiftMockTests/Macro/MockMacroTests.swift
@@ -92,7 +92,7 @@ final class MockMacroTests: XCTestCase {
 				func call()
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -148,7 +148,7 @@ final class MockMacroTests: XCTestCase {
 				var prop: Int { get }
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -202,7 +202,7 @@ final class MockMacroTests: XCTestCase {
 				var prop: Int { get set }
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -272,7 +272,7 @@ final class MockMacroTests: XCTestCase {
 				var prop: Int { get throws }
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -326,7 +326,7 @@ final class MockMacroTests: XCTestCase {
 				var prop: Int { get async }
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -380,7 +380,7 @@ final class MockMacroTests: XCTestCase {
 				var prop: Int { get async throws }
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -434,7 +434,7 @@ final class MockMacroTests: XCTestCase {
 				func call() -> Int
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -490,7 +490,7 @@ final class MockMacroTests: XCTestCase {
 				func call(argument: Int)
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -546,7 +546,7 @@ final class MockMacroTests: XCTestCase {
 				func call(argument0: Int, argument1: Int)
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -604,7 +604,7 @@ final class MockMacroTests: XCTestCase {
 				func call(argument0: Int, argument1: Int) throws -> Int
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer
@@ -662,7 +662,7 @@ final class MockMacroTests: XCTestCase {
 				func call(argument0: Int, argument1: Int) async -> Int
 			}
 			
-			public final class TestMock: Test , Verifiable {
+			public final class TestMock: Test, Verifiable {
 				public struct Verify: MockVerify {
 					let mock: TestMock
 					let container: CallContainer


### PR DESCRIPTION
Remove extra space after protocol name in Mock class inheritance Clause