### PR TITLE
Fixes an issue where asking a mock for values in a concurrent way causes a crash in the VerifyContainer

### DIFF
--- a/Sources/SwiftMock/Verify/VerifyContainer.swift
+++ b/Sources/SwiftMock/Verify/VerifyContainer.swift
@@ -11,15 +11,18 @@ public class VerifyContainer: CallContainer {
 	var calls: [Any] = []
 	var functions: [String] = []
 	var isVerified: [Bool] = []
-	
+    private let queue = DispatchQueue(label: "VerifyContainerQueue")
+
 	public init() { }
 	
 	public func append<T>(mock: AnyObject, call: MethodCall<T>, function: String) {
-		calls.append(call)
-		functions.append(function)
-		isVerified.append(false)
-		
-		InOrderContainer.append(mock: mock, call: call, function: function)
+        queue.sync { [weak self] in
+            self?.calls.append(call)
+            self?.functions.append(function)
+            self?.isVerified.append(false)
+
+            InOrderContainer.append(mock: mock, call: call, function: function)
+        }
 	}
 	
 	public func verify<T>(

--- a/Tests/SwiftMockTests/Macro/MockMacroTests.swift
+++ b/Tests/SwiftMockTests/Macro/MockMacroTests.swift
@@ -11,7 +11,7 @@ private let testMacros: [String: Macro.Type] = [
 #endif
 
 final class MockMacroTests: XCTestCase {
-	func testEmptyProtocol() {
+	func testEmptyProtocol() throws {
 		#if canImport(SwiftMockMacros)
 		assertMacroExpansion(
 			"""
@@ -46,7 +46,7 @@ final class MockMacroTests: XCTestCase {
 		#endif
 	}
 	
-	func testInternalProtocol() {
+	func testInternalProtocol() throws {
 		#if canImport(SwiftMockMacros)
 		assertMacroExpansion(
 			"""
@@ -79,7 +79,7 @@ final class MockMacroTests: XCTestCase {
 		#endif
 	}
 	
-	func testFunctionWithoutArgumentsAndReturnType() {
+	func testFunctionWithoutArgumentsAndReturnType() throws {
 		#if canImport(SwiftMockMacros)
 		assertMacroExpansion(
 			"""
@@ -136,7 +136,7 @@ final class MockMacroTests: XCTestCase {
 		#endif
 	}
 	
-	func testGetProperty() {
+	func testGetProperty() throws {
 		#if canImport(SwiftMockMacros)
 		assertMacroExpansion(
 			"""
@@ -192,7 +192,7 @@ final class MockMacroTests: XCTestCase {
 		#endif
 	}
 	
-	func testGetSetProperty() {
+	func testGetSetProperty() throws {
 		#if canImport(SwiftMockMacros)
 		assertMacroExpansion(
 			"""
@@ -432,7 +432,7 @@ final class MockMacroTests: XCTestCase {
 		#endif
 	}
 
-	func testFunctionWithoutArguments() {
+    func testFunctionWithoutArguments() throws {
 	#if canImport(SwiftMockMacros)
 		assertMacroExpansion(
 			"""
@@ -489,7 +489,7 @@ final class MockMacroTests: XCTestCase {
 		#endif
 	}
 	
-	func testFunctionWitOneArgument() {
+	func testFunctionWitOneArgument() throws {
 		#if canImport(SwiftMockMacros)
 		assertMacroExpansion(
 			"""
@@ -546,7 +546,7 @@ final class MockMacroTests: XCTestCase {
 		#endif
 	}
 	
-	func testFunctionWithTwoArgument() {
+	func testFunctionWithTwoArgument() throws {
 		#if canImport(SwiftMockMacros)
 		assertMacroExpansion(
 			"""
@@ -605,7 +605,7 @@ final class MockMacroTests: XCTestCase {
 		#endif
 	}
 	
-	func testFunctionThatThrows() {
+	func testFunctionThatThrows() throws {
 		#if canImport(SwiftMockMacros)
 		assertMacroExpansion(
 			"""
@@ -664,7 +664,7 @@ final class MockMacroTests: XCTestCase {
 		#endif
 	}
 	
-	func testAsyncFunction() {
+	func testAsyncFunction() throws {
 		#if canImport(SwiftMockMacros)
 		assertMacroExpansion(
 			"""
@@ -723,7 +723,7 @@ final class MockMacroTests: XCTestCase {
 		#endif
 	}
 	
-	func testAsyncThrowsFunction() {
+	func testAsyncThrowsFunction() throws {
 		#if canImport(SwiftMockMacros)
 		assertMacroExpansion(
 			"""

--- a/Tests/SwiftMockTests/MethodStubbingTests.swift
+++ b/Tests/SwiftMockTests/MethodStubbingTests.swift
@@ -177,7 +177,29 @@ final class MethodStubbingTests: XCTestCase {
 		}
 		XCTAssertNil(catchedError)
 	}
-	
+
+    func testConcurrentMockAccess() throws {
+        let mock = SimpleProtocolMock()
+        let expectation = -1
+        when(mock.$call()).thenReturn(expectation)
+
+        let xcTestExpectation = XCTestExpectation()
+        xcTestExpectation.expectedFulfillmentCount = 400
+        DispatchQueue.concurrentPerform(iterations: 200) { number in
+            let actual = mock.call()
+            XCTAssertEqual(expectation, actual)
+            xcTestExpectation.fulfill()
+        }
+
+        DispatchQueue.concurrentPerform(iterations: 200) { number in
+            let actual = mock.call()
+            XCTAssertEqual(expectation, actual)
+            xcTestExpectation.fulfill()
+        }
+
+        wait(for: [xcTestExpectation])
+    }
+
 	func testGenericWithOneParameter() {
 		let mock = GenericMethodProtocolMock()
 		


### PR DESCRIPTION
If we try to access a mocked value when another thread is accessing the mock at the same time, we can get a crash.

We're seeing this consistently when we're running Xcode tests repeatedly.

We're now appending to the arrays in `VerifyContainer` and `InOrderContainer` in a thread-safe manner.